### PR TITLE
finish cmd_edit + surface launch errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ undo            remove last line
 clear           reset to blank
 list            show current code
 del <n>         delete line n
-edit            open in $EDITOR
+edit            live-edit (^S save, ^C cancel)
 examples        show built-in presets
 wormhole        moiré wormhole
 acid            acid grid
@@ -55,7 +55,15 @@ palette fire    switch palette
 chars kawaii    switch character set
 ```
 
-**palettes:** `rainbow` `fire` `plasma` `green` `gold` `fiesta` `mono` `acid` `acid2` `toxic` `lava` `electricity`
+**Edit mode**
+
+`edit` opens a live-editor session over the current shaer. Type to mutate and every keystroke compiles and updates the canvas in real-time.
+
+- `^S` - save & exit
+- `^C` - cancel and revert to pre-edit sahder
+- `enter` - newline
+
+**Palettes:** `rainbow` `fire` `plasma` `green` `gold` `fiesta` `mono` `acid` `acid2` `toxic` `lava` `electricity`
 
 
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -49,6 +49,10 @@ echo -e "  ${DIM}ok${RESET}   tmux sync"
 
 ### virtual environment
 VENV="$ROOT/.venv"
+if [ -d "$VENV" ] && ! "$VENV/bin/python3" --version &>/dev/null; then
+    echo -e "  ${DIM}venv broken (project moved?), rebuilding${RESET}"
+    rm -rf "$VENV"
+fi
 if [ ! -d "$VENV" ]; then
     python3 -m venv "$VENV"
 fi

--- a/launch.sh
+++ b/launch.sh
@@ -32,5 +32,8 @@ tmux split-window -h -p 35 -t "$SESSION" \
     -e "WEZTERM_EXECUTABLE=${WEZTERM_EXECUTABLE:-}" \
     "$PYTHON $DIR/src/repl.py"
 
+# keep REPL pane open on crash so the traceback stays visible
+tmux set-option -p -t "$SESSION" remain-on-exit on
+
 trap "tmux kill-session -t '$SESSION' 2>/dev/null" EXIT
 tmux attach -t "$SESSION"

--- a/src/repl.py
+++ b/src/repl.py
@@ -223,12 +223,17 @@ def cmd_edit(arg):
             lines = snapshot
             write_shader()
 
-    session = PromptSession(multiline=True, key_bindings=kb)
+    session = PromptSession(
+        multiline=True,
+        key_bindings=kb,
+        prompt_continuation=lambda w, ln, soft: "  ",
+    )
     session.default_buffer.on_text_changed += on_change
     print(f"{DIM}  -- edit mode --{RESET}")
+    print()
     print(f"{DIM}  ^S save  ^C cancel  enter = newline  type to live-edit{RESET}")
-    
-    result = session.prompt("", default="\n".join(lines))
+
+    result = session.prompt("  ", default="\n".join(lines))
 
     if result == "cancel":
         lines = original

--- a/src/repl.py
+++ b/src/repl.py
@@ -225,6 +225,9 @@ def cmd_edit(arg):
 
     session = PromptSession(multiline=True, key_bindings=kb)
     session.default_buffer.on_text_changed += on_change
+    print(f"{DIM}  -- edit mode --{RESET}")
+    print(f"{DIM}  ^S save  ^C cancel  enter = newline  type to live-edit{RESET}")
+    
     result = session.prompt("", default="\n".join(lines))
 
     if result == "cancel":

--- a/src/repl.py
+++ b/src/repl.py
@@ -222,7 +222,17 @@ def cmd_edit(arg):
         if not ok:
             lines = snapshot
             write_shader()
-    open_editor()
+
+    session = PromptSession(multiline=True, key_bindings=kb)
+    session.default_buffer.on_text_changed += on_change
+    result = session.prompt("", default="\n".join(lines))
+
+    if result == "cancel":
+        lines = original
+        write_shader()
+        print(f"{DIM}  reverted.{RESET}")
+    else:
+        print(f"{DIM}  saved.{RESET}")
 
 ### toggle layout
 def cmd_layout(arg):
@@ -284,7 +294,7 @@ print("  Commands")
 print(f"  {DIM}<enter>  = add line          undo    = remove last line{RESET}")
 print(f"  {DIM}list     = show code         clear   = reset{RESET}")
 print(f"  {DIM}palette  = show/set palette  chars   = show/set charset{RESET}")
-print(f"  {DIM}examples = show presets      edit    = open in $EDITOR{RESET}")
+print(f"  {DIM}examples = show presets      edit    = live-edit (^S save, ^C cancel){RESET}")
 print(f"  {DIM}layout   = toggle horiz/vert split{RESET}")
 print()
 show()


### PR DESCRIPTION
## Summary
- Finishes `cmd_edit` live-edit: adds PromptSession, `on_text_changed` subscription, and finalize block (cancel restores outer snapshot, save prints confirmation). Replaces dead `open_editor()` call that was crashing at runtime.
- Updates startup help text: `edit = live-edit (^S save, ^C cancel)`.
- **launch.sh:** sets `remain-on-exit on` on the REPL pane so crashes stay visible instead of closing too fast to read. This is the durable fix for "I see only the renderer" — any future REPL startup failure will show its traceback in-pane.
- **install.sh:** detects a broken venv (e.g. project directory moved, breaking hardcoded shebang paths) and rebuilds it automatically.

## Test plan
- [ ] On the Pi (or local), re-run `./install/install.sh` to pick up `prompt_toolkit`.
- [ ] `./launch.sh` — REPL pane should appear with prompt.
- [ ] Type `edit` — drops into multiline buffer prefilled with current shader.
- [ ] Type a `v = math.sin(...)` line — canvas updates per keystroke.
- [ ] Type half an expression (`v = math.tan(`) — canvas freezes on last valid frame (inner rollback).
- [ ] Ctrl-C — reverts to pre-edit shader (outer rollback), prints "reverted."
- [ ] Ctrl-S — keeps changes, prints "saved."
- [ ] Sanity: temporarily break repl.py (`raise ValueError("test")` at top), `./launch.sh`, confirm traceback is visible in the REPL pane instead of the pane closing.
- [ ] Sanity: move project to a different directory, re-run `./install/install.sh`, confirm "venv broken, rebuilding" message appears and install completes.